### PR TITLE
Can now check if a key exists in the store without getting its value

### DIFF
--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -20,6 +20,10 @@ impl Store {
         }
     }
 
+    pub fn contains(&self, key: &Key) -> bool {
+        self.data.contains_key(key)
+    }
+
     pub fn set(&mut self, key: Key, value: Value) {
         self.data.insert(key, value); 
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,4 +60,27 @@ mod tests {
             Err(errors::KelueError::KeyNotFoundError) => assert!(true),
         };
     }
+
+    #[test]
+    fn store_contains_just_created_key() {
+        let mut store = Store::new();
+        let key: Key = Key::String("name".to_string());
+        let value: Value = Value::String("value".to_string());
+
+        store.set(key.clone(), value);
+        assert!(store.contains(&key));
+    }
+    
+    #[test]
+    fn store_does_not_contain_deleted_key() {
+        let mut store = Store::new();
+        let key: Key = Key::String("name".to_string());
+        let value: Value = Value::String("value".to_string());
+
+        store.set(key.clone(), value);
+        match store.erase(key.clone()) {
+            Ok(_) => assert!(!store.contains(&key)),
+            Err(errors::KelueError::KeyNotFoundError) => panic!("This should NOT happen as the store contains the key"),
+        }
+    }
 }


### PR DESCRIPTION
Added the `contains` function to the `store` which returns a boolean indicating whether a given key exists in the store. 